### PR TITLE
package.xml: add missing svn dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="tim.wendt@alumni.fh-aachen.de">Tim Wendt</maintainer>
   <license>MIT-0</license> <!-- License of both CLIPS (Copyright 2023 Secret Society Software, LLC) and this package -->
   <depend>ament_cmake_vendor_package</depend>
+  <depend>libsvn-dev</depend>
   <depend condition="$BUILD_WITH_JAVA_EXAMPLES != ''"> java</depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
I thought that would already be covered by ament_vendor_package, I was wrong.
Here the error from the build farm:
```
02:06:10 -- Build files have been written to: /tmp/ws/build_isolated/clips_vendor
02:06:10 [ 14%] Creating directories for 'clips_vendor'
02:06:10 [ 28%] Performing download step for 'clips_vendor'
02:06:10 === ./clips_vendor (svn) ===
02:06:10 Invocation of command 'import' on client 'svn' failed: AssertionError: Could not find 'svn' executable (/usr/lib/python3/dist-packages/vcstool/clients/svn.py:265)
02:06:10 gmake[2]: *** [CMakeFiles/clips_vendor.dir/build.make:98: clips_vendor-prefix/src/clips_vendor-stamp/clips_vendor-download] Error 1
02:06:10 gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/clips_vendor.dir/all] Error 2
02:06:10 gmake: *** [Makefile:146: all] Error 2
```