### PR TITLE
CMakLists: reverse patch if source dir exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,21 @@ else()
   message(FATAL_ERROR "git diff failed: ${patch_error}")
 endif()
 
+set(CLIPS_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-prefix/src/${PROJECT_NAME})
+
+if(EXISTS ${CLIPS_SRC_DIR})
+  message(STATUS "Directory exists: ${DIRECTORY_TO_CHECK}, reverse patch ...")
+
+  # Apply the reverse patch silently in case it is still floating around
+  execute_process(
+    COMMAND git apply --no-index -R ${PATCH_FILE}
+    WORKING_DIRECTORY ${CLIPS_SRC_DIR}
+    RESULT_VARIABLE patch_result
+    OUTPUT_QUIET
+    ERROR_QUIET
+  )
+endif()
+
 ament_vendor(${PROJECT_NAME}
   SATISFIED FALSE
   VCS_TYPE svn


### PR DESCRIPTION
Under some circumstances the patch is applied despite artifacts from old builds still being present.
To fix this, check for existance of the source patch before. 
```
3:08:48 Build step 'Execute shell' marked build as failure
23:08:48 [CMakeGNU C Compiler (gcc)Clang-Tidy] Skipping execution of recorder since overall result is 'FAILURE'
23:08:48 INFO: Processing CTest-Version 3.x (default)
23:08:48 INFO: [CTest-Version 3.x (default)] - No test report file(s) were found with the pattern 'ws/test_results/*/Testing/*/Test.xml' relative to '/home/jenkins-agent/workspace/Hdev__clips_vendor__ubuntu_jammy_amd64' for the testing framework 'CTest-Version 3.x (default)'.
23:08:48 Did you enter a pattern relative to (and within) the workspace directory?
23:08:48 Did you generate the result report(s) for 'CTest-Version 3.x (default)'?"
23:08:48 INFO: Processing GoogleTest-1.8
23:08:48 INFO: [GoogleTest-1.8] - No test report file(s) were found with the pattern 'ws/test_results/**/*.gtest.xml' relative to '/home/jenkins-agent/workspace/Hdev__clips_vendor__ubuntu_jammy_amd64' for the testing framework 'GoogleTest-1.8'.
23:08:48 Did you enter a pattern relative to (and within) the workspace directory?
23:08:48 Did you generate the result report(s) for 'GoogleTest-1.8'?"
23:08:48 INFO: Processing JUnit
23:08:48 INFO: [JUnit] - No test report file(s) were found with the pattern 'ws/test_results/*/pytest.xml' relative to '/home/jenkins-agent/workspace/Hdev__clips_vendor__ubuntu_jammy_amd64' for the testing framework 'JUnit'.
23:08:48 Did you enter a pattern relative to (and within) the workspace directory?
23:08:48 Did you generate the result report(s) for 'JUnit'?"
23:08:48 INFO: Processing JUnit
23:08:48 INFO: [JUnit] - No test report file(s) were found with the pattern 'ws/test_results/**/*.xunit.xml' relative to '/home/jenkins-agent/workspace/Hdev__clips_vendor__ubuntu_jammy_amd64' for the testing framework 'JUnit'.
23:08:48 Did you enter a pattern relative to (and within) the workspace directory?
23:08:48 Did you generate the result report(s) for 'JUnit'?"
23:08:48 WARNING: All test reports are empty.
23:08:48 INFO: Check 'Failed Tests' threshold.
23:08:48 INFO: Check 'Skipped Tests' threshold.
```

I have trouble reproducing the actual issue but it kinda make sense if artefacts remain. To avoid this, reverse patch in the beginning if needed.